### PR TITLE
Include build tools in frontend builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:alpine as frontend
 
+# node-sass may not provide a prebuilt (e.g. for arm)
+RUN apk update
+RUN apk add python make g++
 
 RUN mkdir -p /app/client
 WORKDIR /app/client


### PR DESCRIPTION
linux/arm doesn't have prebuilts for some node modules, requiring them to be built in the frontend build stage. This ensures required tools are available.